### PR TITLE
Fix PHPUnit_Framework_Assert not found

### DIFF
--- a/src/AppBundle/Features/Context/RestApiContext.php
+++ b/src/AppBundle/Features/Context/RestApiContext.php
@@ -8,7 +8,7 @@ use Behat\Gherkin\Node\TableNode;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7;
-use PHPUnit_Framework_Assert as Assertions;
+use PHPUnit\Framework\Assert as Assertions;
 use Symfony\Component\HttpFoundation\Request;
 
 /**


### PR DESCRIPTION
Compatibility with the latest phpunit version, in order tu use php7